### PR TITLE
Do not await modbus 'close()' calls

### DIFF
--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -69,9 +69,9 @@ class GrowattModbusBase:
     def connected(self):
         return self.client.connected
 
-    async def close(self):
+    def close(self):
         """Closing the modbus device connection."""
-        await self.client.close()
+        self.client.close()
 
     async def get_device_info(
             self,
@@ -279,8 +279,8 @@ class GrowattDevice:
     def connected(self):
         return self.modbus.connected()
 
-    async def close(self):
-        await self.modbus.close()
+    def close(self):
+        self.modbus.close()
 
     async def get_device_info(self) -> GrowattDeviceInfo:
         return await self.modbus.get_device_info(self.holding_register, self.max_length, self.unit)

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -109,7 +109,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    await hass.data[DOMAIN][entry.data[CONF_SERIAL_NUMBER]].growatt_api.close()
+    hass.data[DOMAIN][entry.data[CONF_SERIAL_NUMBER]].growatt_api.close()
 
     if unload_ok:
         del hass.data[DOMAIN][entry.data[CONF_SERIAL_NUMBER]]

--- a/custom_components/growatt_local/config_flow.py
+++ b/custom_components/growatt_local/config_flow.py
@@ -284,7 +284,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors={"base": "device_disconnect"},
                 )
             finally:
-                await server.close()
+                server.close()
 
             self.server = server
             self.data.update(user_input)
@@ -337,7 +337,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
 
             if not server.connected():
-                await server.close()
+                server.close()
                 return self._async_show_network_form(
                     default_values=(
                         user_input[CONF_IP_ADDRESS],
@@ -380,7 +380,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors={"base": "device_disconnect"},
                 )
             finally:
-                await server.close()
+                server.close()
 
             self.server = server
             self.data.update(user_input)
@@ -442,7 +442,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors={"base": "device_disconnect"},
                 )
             finally:
-                await self.server.close()
+                self.server.close()
 
         if device_info is None:
             return self._async_show_device_form(


### PR DESCRIPTION
pymodbus modbus.close returns 'None' and is not async. Hence, it can not be 'awaited'. This raises the following exception:

   TypeError: object NoneType can't be used in 'await' expression

This commit removes 'await' from all 'close()' calls.