### PR TITLE
Add support up to modbus version 2.2

### DIFF
--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -196,6 +196,8 @@ class InverterStatus(Enum):
     Waiting = 0
     Normal = 1
     Fault = 3
+    Unknown5 = 5  # maybe some warning state if no battery connected
+    Unknown9 = 9  # maybe upgrade planned
 
 
 INVERTER_DERATINGMODES = {
@@ -254,7 +256,7 @@ def inverter_status(value: dict[str, Any]) -> str | None:
     if status_value is InverterStatus.Waiting:
         return status_value.name
 
-    elif status_value == InverterStatus.Normal:
+    elif status_value in [InverterStatus.Normal, InverterStatus.Unknown5, InverterStatus.Unknown9]:
         derating = value.get(ATTR_DERATING_MODE, None)
         if (derating is not None and derating in INVERTER_DERATINGMODES.keys() and derating != 0):
             return f"{status_value.name} - {INVERTER_DERATINGMODES[derating]}"

--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -192,14 +192,14 @@ NUMBER_OF_TRACKERS_AND_PHASES_REGISTER = GrowattDeviceRegisters(
 
 
 class InverterStatus(Enum):
-    "Enum of possible Inverter Status."
+    """Enum of possible Inverter Status."""
     Waiting = 0
     Normal = 1
     Fault = 3
 
 
 INVERTER_DERATINGMODES = {
-    0: "No Deratring",
+    0: "No Derating",
     1: "PV",
     3: "Vac",
     4: "Fac",
@@ -245,7 +245,7 @@ for i in range(1, 24):
 
 
 def inverter_status(value: dict[str, Any]) -> str | None:
-    """Returns status based on multiple registery values."""
+    """Returns status based on multiple registry values."""
     if ATTR_STATUS_CODE not in value.keys():
         return None
 

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -361,7 +361,7 @@ async def get_device_info(device: GrowattModbusBase, unit: int, fixed_device_typ
     inverter_v315 = await device.get_device_info(HOLDING_REGISTERS_315, minimal_length, unit)
     _LOGGER.info(f"Inverter Protocol v3.15: {inverter_v315}")
 
-    if 1.0 < inverter_v120.modbus_version < 1.20:
+    if 1.0 < inverter_v120.modbus_version < 2.3:
         return inverter_v120
     elif 3.0 < inverter_v315.modbus_version < 3.15:
         return inverter_v315


### PR DESCRIPTION
This works with my Growatt SPH6000TL3 BH-UP.
I just couldn't find/figure out yet what inverter status 5 and 9 is,
but the inverter is functional normal and can be accessed from modbus.