### PR TITLE
Add support for disabling inverter

### DIFF
--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -127,6 +127,14 @@ class GrowattModbusBase:
             rhr.register[5],
         )
 
+    async def write_state(
+        self, state: bool
+    ):
+        """Writing current date/time to device."""
+
+        _LOGGER.warning("Writing state register")
+        await self.client.write_register(0, 1 if state else 0)
+
     async def write_device_time(
         self, year: int, month: int, day: int, hour: int, minute: int, second: int
     ):
@@ -280,6 +288,9 @@ class GrowattDevice:
 
     def close(self):
         self.modbus.close()
+
+    async def set_state(self, state: bool):
+        await self.modbus.write_state(state)
 
     async def get_device_info(self) -> GrowattDeviceInfo:
         return await self.modbus.get_device_info(self.holding_register, self.max_length, self.unit)

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -158,6 +158,11 @@ class GrowattLocalCoordinator(DataUpdateCoordinator):
 
         async_track_time_change(self.hass, self.midnight, 0, 0, 0)
 
+
+    async def set_state(self, state: bool):
+        return await self.growatt_api.set_state(state)
+
+
     @callback
     def async_update_listeners(self) -> None:
         """Update only the registered listeners for which we have new data."""

--- a/custom_components/growatt_local/const.py
+++ b/custom_components/growatt_local/const.py
@@ -39,4 +39,4 @@ DEFAULT_NAME = "Growatt Modbus"
 
 DOMAIN = "growatt_local"
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.SENSOR,Platform.SWITCH]

--- a/custom_components/growatt_local/sensor_types/inverter.py
+++ b/custom_components/growatt_local/sensor_types/inverter.py
@@ -19,8 +19,9 @@ from homeassistant.const import (
     PERCENTAGE,
 )
 
-from .sensor_entity_description import GrowattSensorEntityDescription
+from .sensor_entity_description import GrowattSensorEntityDescription,GrowattSwitchEntityDescription
 from ..API.device_type.base import (
+    ATTR_STATUS_CODE,
     ATTR_INPUT_POWER,
     ATTR_INPUT_ENERGY_TOTAL,
     ATTR_INPUT_1_VOLTAGE,
@@ -82,6 +83,15 @@ from ..API.device_type.base import (
     ATTR_IPM_TEMPERATURE,
     ATTR_OUTPUT_PERCENTAGE,
 )
+
+INVERTER_SWITCH_TYPES: tuple[GrowattSwitchEntityDescription, ...] = (
+    GrowattSwitchEntityDescription(
+        key=ATTR_STATUS_CODE,
+        name="Inverter state"
+       
+    ),
+)
+
 
 INVERTER_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     GrowattSensorEntityDescription(

--- a/custom_components/growatt_local/sensor_types/sensor_entity_description.py
+++ b/custom_components/growatt_local/sensor_types/sensor_entity_description.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from collections.abc import Callable, Iterable
 
 from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.core import Event
 
 
@@ -19,3 +20,15 @@ class GrowattRequiredKeysMixin:
 @dataclass
 class GrowattSensorEntityDescription(GrowattRequiredKeysMixin, SensorEntityDescription):
     """Describes Growatt sensor entity."""
+
+
+
+
+
+@dataclass
+class GrowattSwitchEntityDescription(GrowattRequiredKeysMixin, SwitchEntityDescription):
+    """Describes Growatt switch entity."""
+
+
+
+

--- a/custom_components/growatt_local/switch.py
+++ b/custom_components/growatt_local/switch.py
@@ -1,0 +1,196 @@
+from datetime import timedelta
+
+import logging
+import re
+
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.const import (
+    CONF_MODEL,
+    CONF_NAME,
+    CONF_TYPE,
+)
+
+
+from pymodbus.exceptions import ModbusIOException
+
+
+
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+)
+
+from .API.const import DeviceTypes
+from .API.device_type.base import (
+    ATTR_INPUT_POWER,
+    ATTR_OUTPUT_POWER,
+)
+
+from .sensor_types.sensor_entity_description import GrowattSwitchEntityDescription
+from .sensor_types.inverter import INVERTER_SWITCH_TYPES
+from .const import (
+    CONF_AC_PHASES,
+    CONF_DC_STRING,
+    CONF_FIRMWARE,
+    CONF_SERIAL_NUMBER,
+    CONF_POWER_SCAN_ENABLED,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=1)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+
+
+    coordinator = hass.data[DOMAIN][config_entry.data[CONF_SERIAL_NUMBER]]
+
+    entities = []
+    power_sensor = []
+    sensor_descriptions: list[GrowattSwitchEntityDescription] = []
+
+    device_type = DeviceTypes(config_entry.data[CONF_TYPE])
+
+    if device_type in (DeviceTypes.INVERTER, DeviceTypes.INVERTER_315, DeviceTypes.INVERTER_120):
+        supported_key_names = coordinator.growatt_api.get_register_names()
+
+        for sensor in INVERTER_SWITCH_TYPES:
+            if sensor.key not in supported_key_names:
+                continue
+
+            if re.match(r"input_\d+", sensor.key) and not re.match(f"input_[1-{config_entry.data[CONF_DC_STRING]}]", sensor.key):
+                continue
+            elif re.match(r"output_\d+", sensor.key) and not re.match(f"output_[1-{config_entry.data[CONF_AC_PHASES]}]", sensor.key):
+                continue
+
+            sensor_descriptions.append(sensor)
+
+        power_sensor = (ATTR_INPUT_POWER, ATTR_OUTPUT_POWER)
+
+    else:
+        _LOGGER.debug(
+            "Device type %s was found but is not supported right now",
+            config_entry.data[CONF_TYPE],
+        )
+
+    coordinator.get_keys_by_name({sensor.key for sensor in sensor_descriptions}, True)
+
+    if config_entry.data[CONF_POWER_SCAN_ENABLED]:
+        power_keys = coordinator.get_keys_by_name(power_sensor)
+
+        coordinator.p_keys.update(power_keys)
+
+    entities.extend(
+        [
+            GrowattDeviceEntity(
+                coordinator, description=description, entry=config_entry
+            )
+            for description in sensor_descriptions
+        ]
+    )
+
+    async_add_entities(entities, True)
+
+
+class GrowattDeviceEntity(CoordinatorEntity, RestoreEntity, SwitchEntity):
+    """An entity using CoordinatorEntity."""
+
+    def __init__(self, coordinator, description, entry):
+        """Pass coordinator to CoordinatorEntity."""
+
+
+        self._is_on = False
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{DOMAIN}_{entry.data[CONF_SERIAL_NUMBER]}_sw_{description.key}"
+        )
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data[CONF_SERIAL_NUMBER])},
+            manufacturer="Growatt",
+            model=entry.data[CONF_MODEL],
+            sw_version=entry.data[CONF_FIRMWARE],
+            name=entry.data[CONF_NAME],
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is about to be added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        if self.entity_description.midnight_reset:
+            self.async_on_remove(
+                self.coordinator.async_add_midnight_listener(
+                    self._handle_midnight_update, self.coordinator_context
+                )
+            )
+
+        if (state := await self.async_get_last_state()) is None:
+            return
+
+        self._attr_native_value = state.state
+
+    @property
+    def is_on(self):
+        """If the switch is currently on or off."""
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+
+        _LOGGER.warning(
+            "Turn inverter on"
+        )
+        self._is_on = True
+        try:
+            await self.coordinator.set_state(True)
+        except ModbusIOException:
+            pass; #ignore growatt empty response
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self._is_on = False
+
+        _LOGGER.warning(
+            "Turn inverter off"
+        )
+
+        try:
+            await self.coordinator.set_state(False)
+
+        except ModbusIOException:
+            pass; #ignore growatt empty response
+        self.async_write_ha_state()
+
+
+
+
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if (state := self.coordinator.data.get(self.entity_description.key)) is None:
+            return
+
+
+        _LOGGER.warning(
+            "Update inverter state: %s", state
+        )
+
+        self._is_on = (state == 1)
+        self._attr_native_value = self._is_on
+        self.async_write_ha_state()
+
+


### PR DESCRIPTION
I have added a switch to be able to enable / disable the inverter during negative pricing in my dynamic contract. No very clean yet, but  it does work and might of value to someone else too. 

Also I had to catch ModbusIOException as the inverter I have doesn' t reply to a command somehow, not sure how else to fix this with pymodbus. Writing enable to the inverter from the CLI also gives me an error:

./modpoll -m enc -a 1  -r 1 -c 1 -1  -p 5279 192.168.10.11 1
modpoll 3.10 - FieldTalk(tm) Modbus(R) Master Simulator
Copyright (c) 2002-2021 proconX Pty Ltd
Visit https://www.modbusdriver.com for Modbus libraries and tools.

Protocol configuration: Encapsulated RTU over TCP, FC6
Slave configuration...: address = 1, start reference = 1, count = 1
Communication.........: 192.168.10.11, port 5279, t/o 1.00 s, poll rate 1000 ms
Data type.............: 16-bit register, output (holding) register table

Invalid reply error!


Can we somehow get this feature into the main code?