### PR TITLE
Refactored names to match with Shine SPF6000ES

### DIFF
--- a/custom_components/growatt_local/config_flow.py
+++ b/custom_components/growatt_local/config_flow.py
@@ -62,9 +62,9 @@ MODBUS_FRAMER_OPTION = [
 
 DEVICETYPES_OPTION = [
     selector.SelectOptionDict(value=DeviceTypes.INVERTER_120, label="RTU 2 - Inverter v1.24"),
-    selector.SelectOptionDict(value=DeviceTypes.HYBRIDE_120, label="RTU 2 - Hybride v1.24"),
+    selector.SelectOptionDict(value=DeviceTypes.HYBRIDE_120, label="RTU 2 - Hybrid v1.24"),
     selector.SelectOptionDict(value=DeviceTypes.INVERTER_315, label="RTU - Inverter v3.15"),
-    selector.SelectOptionDict(value=DeviceTypes.OFFGRID_SPF, label="SPF - Offgrid"),
+    selector.SelectOptionDict(value=DeviceTypes.OFFGRID_SPF, label="SPF - Offgrid/Hybrid"),
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/growatt_local/sensor_types/offgrid.py
+++ b/custom_components/growatt_local/sensor_types/offgrid.py
@@ -84,7 +84,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_INPUT_1_ENERGY_TOTAL,
-        name="PV1 total energy produced",
+        name="PV1 energy produced Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -117,7 +117,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_INPUT_2_ENERGY_TOTAL,
-        name="PV2 total energy produced",
+        name="PV2 energy produced Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -185,7 +185,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_CHARGE_ENERGY_TOTAL,
-        name="Battery Charged Total",
+        name="Grid Charged Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -212,7 +212,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_DISCHARGE_ENERGY_TOTAL,
-        name="Battery Discharged Total",
+        name="Battery Discharged Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -227,7 +227,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_AC_DISCHARGE_TOTAL,
-        name="AC Discharged Total",
+        name="Grid Discharged Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -258,7 +258,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_LOAD_PERCENTAGE,
-        name="Battery load",
+        name="Inverter load",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY
     ),


### PR DESCRIPTION
Follow up to my [previous message](https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/pull/18#issuecomment-2351599086), here are some suggested changes inspired from the Growatt Wifi component:

- "xxx total" could be called "Lifetime xxx" to be clear about the time period.
- "AC Discharged Total" is "Lifetime Grid Discharged"
- "Battery Charged total" is "Lifetime Grid Charged"
- "Battery Load" is actually "Inverter Load" on the AC output side.
- SPF is also Hybrid, I first didn't understand I had to select SPF Offgrid in the configuration, I think we should call it Offgrid/Hybrid.
