### PR TITLE
Storage offgrid hybrid inverters with batt power "charging/discharging(-ve)"

### DIFF
--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -146,6 +146,7 @@ ATTR_BATTERY_DISCHARGE_AMPERAGE = "battery_discharge_amperage"  # A
 ATTR_AC_DISCHARGE_TODAY = "ac_discharge_energy_today"  # kWh
 ATTR_AC_DISCHARGE_TOTAL = "ac_discharge_energy_total"  # kWh
 
+ATTR_BATTERY_POWER = "battery_power"  # W
 
 class custom_function(type):
     """

--- a/custom_components/growatt_local/API/device_type/offgrid.py
+++ b/custom_components/growatt_local/API/device_type/offgrid.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Any
 from .base import (
     GrowattDeviceRegisters,
+    custom_function,
     ATTR_STATUS_CODE,
     ATTR_FAULT_CODE,
     ATTR_WARNING_CODE,
@@ -137,6 +138,15 @@ def offgrid_status(value: dict[str, Any]) -> str | None:
     return status_value.name
 
 
+def batt_watt(registers) -> float:
+   value = (registers[0] << 16) + registers[1]
+   if (value & 0x80000000) == 0x80000000 :
+      neg = ~0xFFFFFFFF
+   else:
+      neg = 0
+   return round(float(-1 * int(neg + value)) / 10, 3)
+
+
 INPUT_REGISTERS_OFFGRID: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
         name=ATTR_STATUS_CODE, register=0, value_type=int
@@ -255,12 +265,16 @@ INPUT_REGISTERS_OFFGRID: tuple[GrowattDeviceRegisters, ...] = (
         name=ATTR_AC_CHARGE_AMPERAGE, register=68, value_type=float,
     ),
     GrowattDeviceRegisters(
-        name=ATTR_DISCHARGE_POWER, register=69, value_type=float,
+        name=ATTR_DISCHARGE_POWER, register=69, value_type=float, length=2
     ),
     GrowattDeviceRegisters(
         name=ATTR_BATTERY_DISCHARGE_AMPERAGE, register=73, value_type=float,
     ),
     GrowattDeviceRegisters(
-        name=ATTR_BATTERY_POWER, register=77, value_type=int, length=2
+        name=ATTR_BATTERY_POWER,
+        register=77,
+        value_type=custom_function,
+        length=2,
+        function=batt_watt
     )
 )

--- a/custom_components/growatt_local/API/device_type/offgrid.py
+++ b/custom_components/growatt_local/API/device_type/offgrid.py
@@ -37,6 +37,7 @@ from .base import (
     ATTR_BATTERY_P_VOLTAGE,
     ATTR_BATTERY_B_VOLTAGE,
     ATTR_BATTERY_DISCHARGE_AMPERAGE,
+    ATTR_BATTERY_POWER,
     ATTR_CHARGE_ENERGY_TODAY,
     ATTR_CHARGE_ENERGY_TOTAL,
     ATTR_DISCHARGE_ENERGY_TODAY,
@@ -258,5 +259,8 @@ INPUT_REGISTERS_OFFGRID: tuple[GrowattDeviceRegisters, ...] = (
     ),
     GrowattDeviceRegisters(
         name=ATTR_BATTERY_DISCHARGE_AMPERAGE, register=73, value_type=float,
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_BATTERY_POWER, register=77, value_type=int, length=2
     )
 )

--- a/custom_components/growatt_local/config_flow.py
+++ b/custom_components/growatt_local/config_flow.py
@@ -62,9 +62,9 @@ MODBUS_FRAMER_OPTION = [
 
 DEVICETYPES_OPTION = [
     selector.SelectOptionDict(value=DeviceTypes.INVERTER_120, label="RTU 2 - Inverter v1.24"),
-    selector.SelectOptionDict(value=DeviceTypes.HYBRIDE_120, label="RTU 2 - Hybride v1.24"),
+    selector.SelectOptionDict(value=DeviceTypes.HYBRIDE_120, label="RTU 2 - Hybrid v1.24"),
     selector.SelectOptionDict(value=DeviceTypes.INVERTER_315, label="RTU - Inverter v3.15"),
-    selector.SelectOptionDict(value=DeviceTypes.OFFGRID_SPF, label="SPF - Offgrid"),
+    selector.SelectOptionDict(value=DeviceTypes.OFFGRID_SPF, label="SPF - Offgrid/Hybrid"),
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/growatt_local/sensor_types/offgrid.py
+++ b/custom_components/growatt_local/sensor_types/offgrid.py
@@ -47,6 +47,7 @@ from ..API.device_type.base import (
     ATTR_BATTERY_B_VOLTAGE,
     ATTR_AC_CHARGE_AMPERAGE,
     ATTR_BATTERY_DISCHARGE_AMPERAGE,
+    ATTR_BATTERY_POWER,
     ATTR_CHARGE_ENERGY_TODAY,
     ATTR_CHARGE_ENERGY_TOTAL,
     ATTR_DISCHARGE_ENERGY_TODAY,
@@ -285,6 +286,12 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         name="Battery bus voltage",
         native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
+    ),
+    GrowattSensorEntityDescription(
+        key=ATTR_BATTERY_POWER,
+        name="Battery charging/ discharging(-ve)",
+        native_unit_of_measurement=POWER_WATT,
+        device_class=SensorDeviceClass.POWER,
     ),
     GrowattSensorEntityDescription(
         key="status",

--- a/custom_components/growatt_local/sensor_types/offgrid.py
+++ b/custom_components/growatt_local/sensor_types/offgrid.py
@@ -84,7 +84,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_INPUT_1_ENERGY_TOTAL,
-        name="PV1 total energy produced",
+        name="PV1 energy produced Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -117,7 +117,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_INPUT_2_ENERGY_TOTAL,
-        name="PV2 total energy produced",
+        name="PV2 energy produced Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -185,7 +185,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_CHARGE_ENERGY_TOTAL,
-        name="Battery Charged Total",
+        name="Grid Charged Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -212,7 +212,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_DISCHARGE_ENERGY_TOTAL,
-        name="Battery Discharged Total",
+        name="Battery Discharged Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -227,7 +227,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_AC_DISCHARGE_TOTAL,
-        name="AC Discharged Total",
+        name="Grid Discharged Lifetime",
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -258,7 +258,7 @@ OFFGRID_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
     ),
     GrowattSensorEntityDescription(
         key=ATTR_LOAD_PERCENTAGE,
-        name="Battery load",
+        name="Inverter load",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY
     ),


### PR DESCRIPTION
Follow up to my https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/pull/18#issuecomment-2351599086, here are some suggested changes inspired from the Growatt Wifi component:
- useful to add "Storage charging/ discharging(-ve)" which indicates the instantaneous kW going in (positive) or out (negative) of the battery, I use this for automation to enable extra loads as it's a good indicator of potential excess solar.
