### PR TITLE
Prevent restoring a string when numeric value is expected

### DIFF
--- a/custom_components/growatt_local/sensor.py
+++ b/custom_components/growatt_local/sensor.py
@@ -14,6 +14,8 @@ from homeassistant.const import (
     CONF_MODEL,
     CONF_NAME,
     CONF_TYPE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN
 )
 
 from homeassistant.helpers.update_coordinator import (
@@ -165,6 +167,9 @@ class GrowattDeviceEntity(CoordinatorEntity, RestoreEntity, SensorEntity):
             )
 
         if (state := await self.async_get_last_state()) is None:
+            return
+
+        if self._numeric_state_expected and state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return
 
         self._attr_native_value = state.state


### PR DESCRIPTION
Fix to prevent the following error from occurring: 
```
2024-12-21 19:08:03.553 ERROR (MainThread) [homeassistant.components.sensor] Error adding entity sensor.energy_produced_today for domain sensor with platform growatt_local
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 677, in state
    numerical_value = float(value)  # type:ignore[arg-type]
ValueError: could not convert string to float: 'unavailable'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 927, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1384, in add_to_platform_finish
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1023, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1148, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1085, in __async_calculate_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1029, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 679, in state
    raise ValueError(
    ...<5 lines>...
    ) from err
ValueError: Sensor sensor.energy_produced_today has device class 'energy', state class 'total_increasing' unit 'kWh' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: 'unavailable' (<class 'str'>)
```
#39