### PR TITLE
Added Power Limit control

### DIFF
--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -15,6 +15,7 @@ ATTR_MODBUS_VERSION = "modbus version"
 # Attribute names for values in the holding register
 ATTR_INVERTER_ENABLED = "inverter_enabled"
 ATTR_AC_CHARGE_ENABLED = "ac_charge_enabled"
+ATTR_OUTPUT_POWER_LIMIT = "output_power_limit" 
 
 # Attribute names for values in the input register
 ATTR_STATUS = "status"

--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -8,6 +8,7 @@ from .base import (
     DEVICE_TYPE_CODE_REGISTER,
     NUMBER_OF_TRACKERS_AND_PHASES_REGISTER,
     ATTR_INVERTER_ENABLED,
+    ATTR_OUTPUT_POWER_LIMIT,
     ATTR_INVERTER_MODEL,
     ATTR_MODBUS_VERSION,
     ATTR_STATUS_CODE,
@@ -104,6 +105,11 @@ HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
         name=ATTR_INVERTER_ENABLED,
         register=0,
+        value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_OUTPUT_POWER_LIMIT,
+        register=3,
         value_type=int
     ),
     FIRMWARE_REGISTER,

--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -321,13 +321,3 @@ INPUT_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
         name=ATTR_OUTPUT_REACTIVE_ENERGY_TOTAL, register=236, value_type=float, length=2,
     ),
 )
-
-def get_power_limit(self) -> int:
-    """Read the inverter power limit (0–100%) from holding register 3."""
-    return self.read_register(3)
-
-def set_power_limit(self, value: int) -> None:
-    """Write a new inverter power limit (0–100%) to holding register 3."""
-    if not 0 <= value <= 100:
-        raise ValueError("Power limit must be between 0 and 100")
-    self.write_register(3, value)

--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -87,7 +87,6 @@ from .base import (
 
 MAXIMUM_DATA_LENGTH_120 = 100
 
-
 def model(registers) -> str:
     mo = (registers[0] << 16) + registers[1]
     return "A{:X} B{:X} D{:X} T{:X} P{:X} U{:X} M{:X} S{:X}".format(
@@ -100,7 +99,6 @@ def model(registers) -> str:
         (mo & 0x000000F0) >> 4,
         (mo & 0x0000000F)
     )
-
 
 HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
@@ -317,3 +315,13 @@ INPUT_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
         name=ATTR_OUTPUT_REACTIVE_ENERGY_TOTAL, register=236, value_type=float, length=2,
     ),
 )
+
+def get_power_limit(self) -> int:
+    """Read the inverter power limit (0–100%) from holding register 3."""
+    return self.read_register(3)
+
+def set_power_limit(self, value: int) -> None:
+    """Write a new inverter power limit (0–100%) to holding register 3."""
+    if not 0 <= value <= 100:
+        raise ValueError("Power limit must be between 0 and 100")
+    self.write_register(3, value)

--- a/custom_components/growatt_local/API/device_type/inverter_315.py
+++ b/custom_components/growatt_local/API/device_type/inverter_315.py
@@ -8,6 +8,7 @@ from .base import (
     DEVICE_TYPE_CODE_REGISTER,
     NUMBER_OF_TRACKERS_AND_PHASES_REGISTER,
     ATTR_INVERTER_ENABLED,
+    ATTR_OUTPUT_POWER_LIMIT,
     ATTR_INVERTER_MODEL,
     ATTR_MODBUS_VERSION,
     ATTR_STATUS_CODE,
@@ -71,6 +72,11 @@ HOLDING_REGISTERS_315: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(
         name=ATTR_INVERTER_ENABLED,
         register=0,
+        value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_OUTPUT_POWER_LIMIT,
+        register=3,
         value_type=int
     ),
     FIRMWARE_REGISTER,

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -278,6 +278,26 @@ class GrowattDevice:
     def close(self):
         self.modbus.close()
 
+
+
+    async def get_power_limit(self) -> int:
+        result = await self.modbus.read_holding_registers(3, 1, slave=1)
+
+        if not result or not isinstance(result, dict):
+            _LOGGER.warning("MODBUS result invalid or unexpected format: %s", result)
+            return 0
+
+        value = result.get(3, 0)
+        _LOGGER.debug("Decoded power limit value: %s", value)
+        return value
+
+
+
+    async def set_power_limit(self, value: int) -> None:
+        await self.modbus.write_register(3, value, self.slave)
+
+
+
     async def get_device_info(self) -> GrowattDeviceInfo:
         return await self.modbus.get_device_info(self.holding_register, self.max_length, self.slave)
 

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -278,26 +278,6 @@ class GrowattDevice:
     def close(self):
         self.modbus.close()
 
-
-
-    async def get_power_limit(self) -> int:
-        result = await self.modbus.read_holding_registers(3, 1, slave=1)
-
-        if not result or not isinstance(result, dict):
-            _LOGGER.warning("MODBUS result invalid or unexpected format: %s", result)
-            return 0
-
-        value = result.get(3, 0)
-        _LOGGER.debug("Decoded power limit value: %s", value)
-        return value
-
-
-
-    async def set_power_limit(self, value: int) -> None:
-        await self.modbus.write_register(3, value, self.slave)
-
-
-
     async def get_device_info(self) -> GrowattDeviceInfo:
         return await self.modbus.get_device_info(self.holding_register, self.max_length, self.slave)
 

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -281,14 +281,6 @@ class GrowattLocalCoordinator(DataUpdateCoordinator):
 
         if status:
             data["status"] = status
-        
-        try:
-            limit = await self.growatt_api.get_power_limit()
-            _LOGGER.debug("Fetched current power limit from inverter: %s", limit)
-            data["power_limit"] = limit
-        except Exception as e:
-            _LOGGER.warning("Failed to retrieve power limit: %s", e)
-
         return data
 
     async def force_refresh(self):

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -281,6 +281,13 @@ class GrowattLocalCoordinator(DataUpdateCoordinator):
 
         if status:
             data["status"] = status
+        
+        try:
+            limit = await self.growatt_api.get_power_limit()
+            _LOGGER.debug("Fetched current power limit from inverter: %s", limit)
+            data["power_limit"] = limit
+        except Exception as e:
+            _LOGGER.warning("Failed to retrieve power limit: %s", e)
 
         return data
 

--- a/custom_components/growatt_local/const.py
+++ b/custom_components/growatt_local/const.py
@@ -40,4 +40,4 @@ DEFAULT_NAME = "Growatt Modbus"
 
 DOMAIN = "growatt_local"
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]

--- a/custom_components/growatt_local/manifest.json
+++ b/custom_components/growatt_local/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/WouterTuinstra/homeassistant-growatt-local-modbus",
     "issue_tracker": "https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/issues",
-    "dependencies": ["sun","number"],
+    "dependencies": ["sun"],
     "requirements": ["pymodbus>=3.8.3"],
     "codeowners": ["@WouterTuinstra"],
     "iot_class": "local_polling",

--- a/custom_components/growatt_local/manifest.json
+++ b/custom_components/growatt_local/manifest.json
@@ -4,7 +4,7 @@
     "config_flow": true,
     "documentation": "https://github.com/WouterTuinstra/homeassistant-growatt-local-modbus",
     "issue_tracker": "https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/issues",
-    "dependencies": ["sun"],
+    "dependencies": ["sun","number"],
     "requirements": ["pymodbus>=3.8.3"],
     "codeowners": ["@WouterTuinstra"],
     "iot_class": "local_polling",

--- a/custom_components/growatt_local/number.py
+++ b/custom_components/growatt_local/number.py
@@ -1,0 +1,60 @@
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import GrowattLocalCoordinator
+from .const import DOMAIN
+
+INVERTER_POWER_LIMIT_DESCRIPTION = NumberEntityDescription(
+    key="power_limit",
+    name="Power Limit",
+    native_unit_of_measurement="%",
+    native_min_value=0,
+    native_max_value=100,
+    native_step=1,
+    icon="mdi:transmission-tower-export",
+)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: GrowattLocalCoordinator = hass.data[DOMAIN][entry.data["serial_number"]]
+    async_add_entities([
+        InverterPowerLimitEntity(coordinator, entry, INVERTER_POWER_LIMIT_DESCRIPTION)
+    ])
+    
+class InverterPowerLimitEntity(CoordinatorEntity, NumberEntity):
+    def __init__(self, coordinator, entry, description):
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self.config_entry = entry
+        self.entity_description = description
+        self._attr_has_entity_name = True
+        self._attr_suggested_object_id = f"{entry.title.lower()}_{description.key}"
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+
+    @property
+    def native_value(self) -> int:
+        return self.coordinator.data.get("power_limit", 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.growatt_api.set_power_limit(int(value))
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (DOMAIN, self.config_entry.data["serial_number"])
+            },
+            "name": self.config_entry.title,
+            "manufacturer": "Growatt",
+            "model": self.config_entry.data.get("model", "Unknown"),
+        }

--- a/custom_components/growatt_local/number.py
+++ b/custom_components/growatt_local/number.py
@@ -1,60 +1,73 @@
-from homeassistant.components.number import (
-    NumberEntity,
-    NumberEntityDescription
-)
+from typing import Optional
+
+from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import GrowattLocalCoordinator
-from .const import DOMAIN
+from homeassistant.const import (
+    CONF_MODEL,
+    CONF_NAME,
+)
 
-INVERTER_POWER_LIMIT_DESCRIPTION = NumberEntityDescription(
-    key="power_limit",
-    name="Power Limit",
-    native_unit_of_measurement="%",
-    native_min_value=0,
-    native_max_value=100,
-    native_step=1,
-    icon="mdi:transmission-tower-export",
+from .API.const import DeviceTypes
+
+from .sensor_types.inverter import INVERTER_OUTPUT_POWER_LIMIT
+from . import GrowattLocalCoordinator
+from .const import (
+    CONF_FIRMWARE,
+    CONF_SERIAL_NUMBER,
+    CONF_INVERTER_POWER_CONTROL,
+    DOMAIN,
 )
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinator: GrowattLocalCoordinator = hass.data[DOMAIN][entry.data["serial_number"]]
-    async_add_entities([
-        InverterPowerLimitEntity(coordinator, entry, INVERTER_POWER_LIMIT_DESCRIPTION)
-    ])
-    
+    coordinator: GrowattLocalCoordinator = hass.data[DOMAIN][config_entry.data[CONF_SERIAL_NUMBER]]
+    entities = []
+
+    if config_entry.options.get(CONF_INVERTER_POWER_CONTROL, False):
+        entities.append(InverterPowerLimitEntity(coordinator, entry=config_entry, description=INVERTER_OUTPUT_POWER_LIMIT))
+        coordinator.get_keys_by_name(INVERTER_OUTPUT_POWER_LIMIT.key, True)
+
+    async_add_entities(entities, True)
+
 class InverterPowerLimitEntity(CoordinatorEntity, NumberEntity):
     def __init__(self, coordinator, entry, description):
-        super().__init__(coordinator)
-        self.coordinator = coordinator
-        self.config_entry = entry
+        super().__init__(coordinator, description.key)
         self.entity_description = description
-        self._attr_has_entity_name = True
-        self._attr_suggested_object_id = f"{entry.title.lower()}_{description.key}"
-        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._config_entry = entry
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data[CONF_SERIAL_NUMBER])},
+            manufacturer="Growatt",
+            model=entry.data[CONF_MODEL],
+            sw_version=entry.data[CONF_FIRMWARE],
+            name=entry.options[CONF_NAME],
+        )
 
     @property
-    def native_value(self) -> int:
-        return self.coordinator.data.get("power_limit", 0)
+    def name(self):
+        return f"{self._config_entry.options[CONF_NAME]} {self.entity_description.name}"
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        return f"{DOMAIN}_{self._config_entry.data[CONF_SERIAL_NUMBER]}_{self.entity_description.key}"
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.growatt_api.set_power_limit(int(value))
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.write_register (self.entity_description.key, int(value))
+        self._attr_native_value = value
+        self.async_write_ha_state()
 
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {
-                (DOMAIN, self.config_entry.data["serial_number"])
-            },
-            "name": self.config_entry.title,
-            "manufacturer": "Growatt",
-            "model": self.config_entry.data.get("model", "Unknown"),
-        }
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if (state := self.coordinator.data.get(self.entity_description.key)) is None:
+            return
+        self._attr_native_value = state
+        self.async_write_ha_state()

--- a/custom_components/growatt_local/number.py
+++ b/custom_components/growatt_local/number.py
@@ -31,9 +31,8 @@ async def async_setup_entry(
     coordinator: GrowattLocalCoordinator = hass.data[DOMAIN][config_entry.data[CONF_SERIAL_NUMBER]]
     entities = []
 
-    if config_entry.options.get(CONF_INVERTER_POWER_CONTROL, False):
-        entities.append(InverterPowerLimitEntity(coordinator, entry=config_entry, description=INVERTER_OUTPUT_POWER_LIMIT))
-        coordinator.get_keys_by_name(INVERTER_OUTPUT_POWER_LIMIT.key, True)
+    entities.append(InverterPowerLimitEntity(coordinator, entry=config_entry, description=INVERTER_OUTPUT_POWER_LIMIT))
+    coordinator.get_keys_by_name(INVERTER_OUTPUT_POWER_LIMIT.key, True)
 
     async_add_entities(entities, True)
 

--- a/custom_components/growatt_local/sensor_types/inverter.py
+++ b/custom_components/growatt_local/sensor_types/inverter.py
@@ -1,6 +1,10 @@
 """Growatt Sensor definitions for the Inverter type."""
 from __future__ import annotations
 
+from homeassistant.components.number.const import (
+    NumberDeviceClass,
+)
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
@@ -15,10 +19,12 @@ from homeassistant.const import (
     UnitOfTime,
     PERCENTAGE,
 )
+from .number_entity_description import GrowattNumberEntityDescription
 from .sensor_entity_description import GrowattSensorEntityDescription
 from .switch_entity_description import GrowattSwitchEntityDescription
 from ..API.device_type.base import (
     ATTR_INVERTER_ENABLED,
+    ATTR_OUTPUT_POWER_LIMIT,
     ATTR_INPUT_POWER,
     ATTR_INPUT_ENERGY_TOTAL,
     ATTR_INPUT_1_VOLTAGE,
@@ -87,6 +93,16 @@ INVERTER_POWER_SWITCH: GrowattSwitchEntityDescription = GrowattSwitchEntityDescr
     state_on=0x1,
     state_off=0x0,
     mask=0x1,
+)
+
+INVERTER_OUTPUT_POWER_LIMIT = GrowattNumberEntityDescription(
+    key=ATTR_OUTPUT_POWER_LIMIT,
+    name="Output Power Limit",
+    native_unit_of_measurement=NumberDeviceClass.POWER_FACTOR,
+    native_min_value=0,
+    native_max_value=100,
+    native_step=1,
+    icon="mdi:transmission-tower-export",
 )
 
 INVERTER_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (

--- a/custom_components/growatt_local/sensor_types/inverter.py
+++ b/custom_components/growatt_local/sensor_types/inverter.py
@@ -1,10 +1,6 @@
 """Growatt Sensor definitions for the Inverter type."""
 from __future__ import annotations
 
-from homeassistant.components.number.const import (
-    NumberDeviceClass,
-)
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
@@ -98,7 +94,7 @@ INVERTER_POWER_SWITCH: GrowattSwitchEntityDescription = GrowattSwitchEntityDescr
 INVERTER_OUTPUT_POWER_LIMIT = GrowattNumberEntityDescription(
     key=ATTR_OUTPUT_POWER_LIMIT,
     name="Output Power Limit",
-    native_unit_of_measurement=NumberDeviceClass.POWER_FACTOR,
+    native_unit_of_measurement=SensorDeviceClass.POWER_FACTOR,
     native_min_value=0,
     native_max_value=100,
     native_step=1,

--- a/custom_components/growatt_local/sensor_types/number_entity_description.py
+++ b/custom_components/growatt_local/sensor_types/number_entity_description.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.switch import SwitchEntityDescription
+
+from homeassistant.components.number import NumberEntityDescription
+
+@dataclass
+class GrowattNumberRequiredKeysMixin:
+    """Mixin for required keys."""
+    key: str
+
+
+
+@dataclass
+class GrowattNumberEntityDescription(NumberEntityDescription, GrowattNumberRequiredKeysMixin):
+    """Describes Growatt number entity."""
+
+

--- a/custom_components/growatt_local/sensor_types/number_entity_description.py
+++ b/custom_components/growatt_local/sensor_types/number_entity_description.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from homeassistant.components.switch import SwitchEntityDescription
-
 from homeassistant.components.number import NumberEntityDescription
 
 @dataclass


### PR DESCRIPTION
The original integration provides the option to turn the inverter on or off. This is a hard cutoff and is similar to using the switch on the inverter. It will kill the MPPT's over time so it's a last resort. Hence the checkbox to unlock the option.

Since power limiting is also an option I want to add this functionality. So now a slider is added called: Power Limit
This has a range of 0 to 100% with 1% steps. It will write to the inverter and read the current value.

I have validated this with Modbus Poll using:
Function 03 Read Holding Registers (4x)
Address mode: Dec
Address: 3
Value range 0 to 100

The changes in the integration are 99.5% done by using Chat GPT to figure it out. It's a big leap for a NOOB like me to get this done. More a powershell guy myself.

So @WouterTuinstra there are some caveats where you might be able to fix it.

- The entity ID is not using the Device Name as a prefix. Instead it's using the Inverter model name. So it's not consistent with the rest. Example: growatt_min_4200tl_x_power_limit

- I have not added any translations. Was a bit unclear to me where in the files and how to format it.

- I have tested this on my Growatt MIN4200TL-X. I can confirm it works fine. But the quality might be lacking a bit to integrate directly into you source.

- It's not checking/updating the value with every modbus read. Only at integration start or when a value is written. If for example the inverter was limited to 50% and the next morning it starts again it will be at 100% by default. But the value in HA will stay at 50%.

Since I got stuck but have a working solution I did this pull request. Hopefully it's easy to adjust so you can include it properly?