### PR TITLE
Fix signed float values

### DIFF
--- a/custom_components/growatt_local/API/utils.py
+++ b/custom_components/growatt_local/API/utils.py
@@ -251,9 +251,10 @@ def process_registers(
             if (second_value := register_values.get(key + 1, None)) is None:
                 continue
 
-            result[register.name] = round(
-                float((value << 16) + second_value) / register.scale, 3
-            )
+            # Handle negative numbers
+            v = (value << 16) | second_value
+            v = v - (v >> 31 << 32)
+            result[register.name] = round(float(v / register.scale), 3)
 
         elif register.value_type == float:
             result[register.name] = round(float(value) / register.scale, 3)


### PR DESCRIPTION
At least in the MID 15KTL-XH the value "output power" seems to be signed:
<img width="2314" height="383" alt="image" src="https://github.com/user-attachments/assets/72c320f2-b95f-4514-9b10-e5dd7a4af2d4" />
