### PR TITLE
Remove slave as argument that should be named device_id

### DIFF
--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -90,7 +90,7 @@ class GrowattModbusBase:
 
         for item in key_sequences:
             register_values.update(
-                await self.read_holding_registers(item[0], count=item[1], slave=device_id)
+                await self.read_holding_registers(item[0], count=item[1], device_id=device_id)
             )
 
         results = process_registers(register, register_values)


### PR DESCRIPTION
`slave_id` is not the correct argument name. Updating to correct name `device_id`. 

Fixes: https://github.com/WouterTuinstra/Homeassistant-Growatt-Local-Modbus/issues/82