### PR TITLE
Fix: Controls for hybrid and storage devices

### DIFF
--- a/custom_components/growatt_local/API/device_type/storage_120.py
+++ b/custom_components/growatt_local/API/device_type/storage_120.py
@@ -6,6 +6,8 @@ from .base import (
     FIRMWARE_REGISTER,
     DEVICE_TYPE_CODE_REGISTER,
     NUMBER_OF_TRACKERS_AND_PHASES_REGISTER,
+    ATTR_INVERTER_ENABLED,
+    ATTR_OUTPUT_POWER_LIMIT,
     ATTR_INVERTER_MODEL,
     ATTR_MODBUS_VERSION,
     ATTR_SOC_PERCENTAGE,
@@ -50,6 +52,16 @@ SERIAL_NUMBER_REGISTER = GrowattDeviceRegisters(
 )
 
 STORAGE_HOLDING_REGISTERS_120: tuple[GrowattDeviceRegisters, ...] = (
+    GrowattDeviceRegisters(
+        name=ATTR_INVERTER_ENABLED,
+        register=0,
+        value_type=int
+    ),
+    GrowattDeviceRegisters(
+        name=ATTR_OUTPUT_POWER_LIMIT,
+        register=3,
+        value_type=int
+    ),
     FIRMWARE_REGISTER,
     SERIAL_NUMBER_REGISTER,
     GrowattDeviceRegisters(


### PR DESCRIPTION
Fixed issue where Power control and Output Power Limit controls did not work with hybrid and storage devices.

The "Power control" and "Output Power Limit" controls did not work for Hybrid (MIN/MOD TL(3)-XH) and storage (MIX, SPA, SPH) devices, because the corresponding registers were not added to the `STORAGE_HOLDING_REGISTERS_120` tuple. 
<img width="283" height="202" alt="image" src="https://github.com/user-attachments/assets/3a4ad82d-e57f-40b2-a842-916d2c6b914d" />
