### PR TITLE
Added configuration for a connected energy meter and added sensor with power of energy meter

### DIFF
--- a/custom_components/growatt_local/API/__init__.py
+++ b/custom_components/growatt_local/API/__init__.py
@@ -1,0 +1,1 @@
+from . import pymodbus_ext  # noqa: F401

--- a/custom_components/growatt_local/API/device_type/base.py
+++ b/custom_components/growatt_local/API/device_type/base.py
@@ -157,6 +157,9 @@ ATTR_AC_DISCHARGE_TOTAL = "ac_discharge_energy_total"  # kWh
 
 ATTR_BATTERY_POWER = "battery_power"  # W
 
+# Attribute names for values in the meter register
+ATTR_METER_TOTAL_ACTIVE_POWER = "meter_total_active_power"  # W
+
 class custom_function(type):
     """
     Object to be used as value_type in a `GrowattDeviceRegisters` that require custom function to translate the register value.

--- a/custom_components/growatt_local/API/device_type/inverter_120.py
+++ b/custom_components/growatt_local/API/device_type/inverter_120.py
@@ -81,12 +81,14 @@ from .base import (
     ATTR_P_BUS_VOLTAGE,
     ATTR_N_BUS_VOLTAGE,
     ATTR_OUTPUT_PERCENTAGE,
+    ATTR_METER_TOTAL_ACTIVE_POWER,
 )
 
 
 
 
 MAXIMUM_DATA_LENGTH_120 = 100
+MAXIMUM_DATA_LENGTH_METER = 50
 
 def model(registers) -> str:
     mo = (registers[0] << 16) + registers[1]
@@ -445,5 +447,11 @@ INPUT_REGISTERS_120_TL_XH: tuple[GrowattDeviceRegisters, ...] = (
     GrowattDeviceRegisters(name=ATTR_FAULT_CODE, register=3105, value_type=int),
     GrowattDeviceRegisters(
         name=ATTR_WARNING_CODE, register=3110, value_type=int, length=2
+    ),
+)
+
+METER_REGISTERS_138: tuple[GrowattDeviceRegisters, ...] = (
+    GrowattDeviceRegisters(
+        name=ATTR_METER_TOTAL_ACTIVE_POWER, register=38, value_type=float, length=2
     ),
 )

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -442,12 +442,15 @@ def get_register_information(GrowattDeviceType: DeviceTypes) -> DeviceRegisters:
             obj.register: obj for obj in INPUT_REGISTERS_OFFGRID
         }
     elif GrowattDeviceType == DeviceTypes.INVERTER_120:
-        max_length = MAXIMUM_DATA_LENGTH_120
+        max_length = min(MAXIMUM_DATA_LENGTH_120, MAXIMUM_DATA_LENGTH_METER)
         holding_register = {
             obj.register: obj for obj in HOLDING_REGISTERS_120
         }
         input_register = {
             obj.register: obj for obj in INPUT_REGISTERS_120
+        }
+        meter_register = {
+            obj.register: obj for obj in METER_REGISTERS_138
         }
     elif GrowattDeviceType == DeviceTypes.HYBRID_120:
         max_length = min(MAXIMUM_DATA_LENGTH_120, MAXIMUM_DATA_LENGTH_METER)

--- a/custom_components/growatt_local/API/growatt.py
+++ b/custom_components/growatt_local/API/growatt.py
@@ -33,7 +33,14 @@ from .device_type.base import (
     ATTR_STATUS_CODE,
     inverter_status,
 )
-from .device_type.inverter_120 import MAXIMUM_DATA_LENGTH_120, HOLDING_REGISTERS_120, INPUT_REGISTERS_120, INPUT_REGISTERS_120_TL_XH
+from .device_type.inverter_120 import (
+    MAXIMUM_DATA_LENGTH_120, 
+    MAXIMUM_DATA_LENGTH_METER, 
+    HOLDING_REGISTERS_120, 
+    INPUT_REGISTERS_120, 
+    INPUT_REGISTERS_120_TL_XH, 
+    METER_REGISTERS_138,
+)
 from .device_type.storage_120 import STORAGE_HOLDING_REGISTERS_120, STORAGE_INPUT_REGISTERS_120, STORAGE_INPUT_REGISTERS_120_TL_XH
 from .device_type.inverter_315 import MAXIMUM_DATA_LENGTH_315, HOLDING_REGISTERS_315, INPUT_REGISTERS_315
 from .device_type.offgrid import INPUT_REGISTERS_OFFGRID, offgrid_status
@@ -153,6 +160,11 @@ class GrowattModbusBase:
         registers = {c: v for c, v in enumerate(data.registers, start_address)}
         return registers
 
+    async def read_meter_registers(self, start_address, count, device_id) -> dict[int, int]:
+        data = await self.client.read_meter_registers(start_address, count=count, device_id=device_id)
+        registers = {c: v for c, v in enumerate(data.registers, start_address)}
+        return registers
+
 
 class GrowattNetwork(GrowattModbusBase):
     def __init__(
@@ -245,6 +257,7 @@ class GrowattSerial(GrowattModbusBase):
 class GrowattDevice:
     holding_register: dict[int, GrowattDeviceRegisters] = {}
     input_register: dict[int, GrowattDeviceRegisters] = {}
+    meter_register: dict[int, GrowattDeviceRegisters] = {}
     max_length: int = 20
 
     def __init__(
@@ -261,6 +274,7 @@ class GrowattDevice:
         self.max_length = self.device_registers.max_length
         self.holding_register = self.device_registers.holding
         self.input_register = self.device_registers.input
+        self.meter_register = self.device_registers.meter
 
         self.device_id = unit
 
@@ -287,8 +301,8 @@ class GrowattDevice:
 
     async def update(self, keys: RegisterKeys) -> dict[str, Any]:
         """
-        Based on the given keys it will generate one or multiple requests to get the corrisponding results
-        from both holding and input registers from the device.
+        Based on the given keys it will generate one or multiple requests to get the corresponding results
+        from both holding, input and meter registers from the device.
 
         returns a dictionary of register name and value
         """
@@ -320,6 +334,15 @@ class GrowattDevice:
                 )
 
             results.update(process_registers(self.device_registers.input, register_values))
+
+        if key_sequences.meter:
+            register_values = {}
+            for item in key_sequences.meter:
+                register_values.update(
+                    await self.modbus.read_meter_registers(item[0], item[1], self.device_id)
+                )
+
+            results.update(process_registers(self.device_registers.meter, register_values))
 
         return results
 
@@ -358,6 +381,11 @@ class GrowattDevice:
                 key
                 for key, register in self.device_registers.input.items()
                 if register.name in names
+            },
+            meter={
+                key
+                for key, register in self.device_registers.meter.items()
+                if register.name in names
             }
         )
 
@@ -371,9 +399,15 @@ class GrowattDevice:
             if register.name == name:
                 return register
 
+    def get_meter_register_by_name(self, name: str) -> Optional[GrowattDeviceRegisters]:
+        for register in self.meter_register.values():
+            if register.name == name:
+                return register
+
     def get_register_names(self) -> set[str]:
         names = {register.name for register in self.input_register.values()}
         names.update({register.name for register in self.holding_register.values()})
+        names.update({register.name for register in self.meter_register.values()})
 
         names.add(ATTR_STATUS)
 
@@ -390,6 +424,7 @@ class GrowattDevice:
 
 
 def get_register_information(GrowattDeviceType: DeviceTypes) -> DeviceRegisters:
+    meter_register = {}
     if GrowattDeviceType in (DeviceTypes.INVERTER, DeviceTypes.INVERTER_315):
         max_length = MAXIMUM_DATA_LENGTH_315
         holding_register = {
@@ -415,7 +450,7 @@ def get_register_information(GrowattDeviceType: DeviceTypes) -> DeviceRegisters:
             obj.register: obj for obj in INPUT_REGISTERS_120
         }
     elif GrowattDeviceType == DeviceTypes.HYBRID_120:
-        max_length = MAXIMUM_DATA_LENGTH_120
+        max_length = min(MAXIMUM_DATA_LENGTH_120, MAXIMUM_DATA_LENGTH_METER)
         holding_register = {
             obj.register: obj for obj in STORAGE_HOLDING_REGISTERS_120
         }
@@ -425,8 +460,11 @@ def get_register_information(GrowattDeviceType: DeviceTypes) -> DeviceRegisters:
         input_register.update({
             obj.register: obj for obj in STORAGE_INPUT_REGISTERS_120
         })
+        meter_register = {
+            obj.register: obj for obj in METER_REGISTERS_138
+        }
     elif GrowattDeviceType == DeviceTypes.HYBRID_120_TL_XH:
-        max_length = MAXIMUM_DATA_LENGTH_120
+        max_length = min(MAXIMUM_DATA_LENGTH_120, MAXIMUM_DATA_LENGTH_METER)
         holding_register = {
             obj.register: obj for obj in STORAGE_HOLDING_REGISTERS_120
         }
@@ -436,18 +474,24 @@ def get_register_information(GrowattDeviceType: DeviceTypes) -> DeviceRegisters:
         input_register.update({
             obj.register: obj for obj in STORAGE_INPUT_REGISTERS_120_TL_XH
         })
+        meter_register = {
+            obj.register: obj for obj in METER_REGISTERS_138
+        }
     elif GrowattDeviceType == DeviceTypes.STORAGE_120:
-        max_length = MAXIMUM_DATA_LENGTH_120
+        max_length = min(MAXIMUM_DATA_LENGTH_120, MAXIMUM_DATA_LENGTH_METER)
         holding_register = {
             obj.register: obj for obj in STORAGE_HOLDING_REGISTERS_120
         }
         input_register = {
             obj.register: obj for obj in STORAGE_INPUT_REGISTERS_120
         }
+        meter_register = {
+            obj.register: obj for obj in METER_REGISTERS_138
+        }
     else:
         raise TypeError("Unsupported Growatt device type")
 
-    return DeviceRegisters(holding_register, input_register, max_length)
+    return DeviceRegisters(holding_register, input_register, meter_register, max_length)
 
 
 async def get_device_info(device: GrowattModbusBase, unit: int, fixed_device_types: DeviceTypes | None = None) -> GrowattDeviceInfo | None:

--- a/custom_components/growatt_local/API/pymodbus_ext.py
+++ b/custom_components/growatt_local/API/pymodbus_ext.py
@@ -1,0 +1,46 @@
+"""
+Extension for pymodbus with custom modbus function codes.
+"""
+from pymodbus.client.mixin import ModbusClientMixin, T
+from pymodbus.pdu.decoders import DecodePDU
+from pymodbus.pdu.register_message import ReadInputRegistersRequest, ReadInputRegistersResponse
+
+
+class ReadMeterRegistersRequest(ReadInputRegistersRequest):
+    """ReadMeterRegistersRequest."""
+
+    function_code = 0x20
+
+
+class ReadMeterRegistersResponse(ReadInputRegistersResponse):
+    """ReadMeterRegistersResponse."""
+
+    function_code = 0x20
+
+
+DecodePDU.add_pdu(ReadMeterRegistersRequest, ReadMeterRegistersResponse)
+
+def read_meter_registers(self,
+                         address: int,
+                         *,
+                         count: int = 1,
+                         device_id: int = 1,
+                         no_response_expected: bool = False) -> T:
+    """Read meter registers (code 0x20).
+
+    :param address: Start address to read from
+    :param count: (optional) Number of registers to read
+    :param device_id: (optional) Modbus device ID
+    :param no_response_expected: (optional) The client will not expect a response to the request
+    :raises ModbusException:
+
+    This function is used to read from 1 to approx. 50 contiguous
+    meter registers in a remote device. The Request specifies the
+    starting register address and the number of registers.
+
+    Registers are addressed starting at zero.
+    Therefore devices that specify 1-16 are addressed as 0-15.
+    """
+    return self.execute(no_response_expected, ReadMeterRegistersRequest(address=address, count=count, dev_id=device_id))
+
+ModbusClientMixin.read_meter_registers = read_meter_registers  # ty:ignore[unresolved-attribute]

--- a/custom_components/growatt_local/API/utils.py
+++ b/custom_components/growatt_local/API/utils.py
@@ -27,6 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 class DeviceRegisters:
     holding: dict[int, GrowattDeviceRegisters]
     input: dict[int, GrowattDeviceRegisters]
+    meter: dict[int, GrowattDeviceRegisters]
     max_length: int
 
 
@@ -34,25 +35,28 @@ class DeviceRegisters:
 class RegisterKeys:
     holding: set[int] = field(default_factory=set)
     input: set[int] = field(default_factory=set)
+    meter: set[int] = field(default_factory=set)
 
     def __len__(self):
-        return len(self.holding) + len(self.input)
+        return len(self.holding) + len(self.input) + len(self.meter)
 
     def __hash__(self) -> int:
-        return hash((frozenset(self.holding), frozenset(self.input)))
+        return hash((frozenset(self.holding), frozenset(self.input), frozenset(self.meter)))
 
     def update(self, register_keys: "RegisterKeys") -> None:
         self.holding.update(register_keys.holding)
         self.input.update(register_keys.input)
+        self.meter.update(register_keys.meter)
 
 
 @dataclass
 class RegisterSequences:
     holding: set[tuple[int, int]] = field(default_factory=set)
     input: set[tuple[int, int]] = field(default_factory=set)
+    meter: set[tuple[int, int]] = field(default_factory=set)
 
     def __len__(self):
-        return len(self.holding) + len(self.input)
+        return len(self.holding) + len(self.input) + len(self.meter)
 
 
 def register_sequences(
@@ -70,7 +74,12 @@ def register_sequences(
     else:
         input_sequence = set()
 
-    return RegisterSequences(holding_sequence, input_sequence)
+    if register_keys.meter:
+        meter_sequence = keys_sequences(get_all_keys_from_register(device_registers.meter, register_keys.meter), device_registers.max_length)
+    else:
+        meter_sequence = set()
+
+    return RegisterSequences(holding_sequence, input_sequence, meter_sequence)
 
 
 def get_keys_from_register(register: dict[int, GrowattDeviceRegisters]) -> set[int]:

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -366,6 +366,9 @@ class GrowattLocalCoordinator(DataUpdateCoordinator):
     def get_holding_register_by_name(self, name: str) -> GrowattDeviceRegisters | None:
         return self.growatt_api.get_holding_register_by_name(name)
 
+    def get_meter_register_by_name(self, name: str) -> GrowattDeviceRegisters | None:
+        return self.growatt_api.get_meter_register_by_name(name)
+
     async def write_register(self, key: str, payload):
         register = self.growatt_api.get_holding_register_by_name(key)
         #TODO: better logging 

--- a/custom_components/growatt_local/__init__.py
+++ b/custom_components/growatt_local/__init__.py
@@ -48,6 +48,7 @@ from .const import (
     CONF_BYTESIZE,
     CONF_PARITY,
     CONF_STOPBITS,
+    CONF_METER_CONNECTED,
     CONF_POWER_SCAN_ENABLED,
     CONF_POWER_SCAN_INTERVAL,
     CONF_INVERTER_POWER_CONTROL,
@@ -169,9 +170,13 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         if config_entry.minor_version < 4:
             # Added Inverter power control in naming options of config entity
             new_options[CONF_INVERTER_POWER_CONTROL] = False
+            
+        if config_entry.minor_version < 5:
+            # Added Meter Connected option in naming options of config entity
+            new_options[CONF_METER_CONNECTED] = False
 
 
-        hass.config_entries.async_update_entry(config_entry, data=new_data, options=new_options, minor_version=4, version=1)
+        hass.config_entries.async_update_entry(config_entry, data=new_data, options=new_options, minor_version=5, version=1)
 
     _LOGGER.debug("Migration to configuration version %s.%s successful", config_entry.version, config_entry.minor_version)
 

--- a/custom_components/growatt_local/config_flow.py
+++ b/custom_components/growatt_local/config_flow.py
@@ -62,10 +62,10 @@ MODBUS_FRAMER_OPTION = [
 ]
 
 DEVICETYPES_OPTION = [
-    selector.SelectOptionDict(value=DeviceTypes.INVERTER_120, label="RTU 2 - Inverter TL3-X (MAX, MID MAC Type)"),
-    selector.SelectOptionDict(value=DeviceTypes.HYBRID_120, label="RTU 2 - Storage (MIX Type, SPA, SPH)"),
-    selector.SelectOptionDict(value=DeviceTypes.HYBRID_120_TL_XH, label="RTU 2 - Hybrid TL-X(H) (MIN Type)"),
-    selector.SelectOptionDict(value=DeviceTypes.INVERTER_315, label="RTU - Inverter (Older regeneration) v3.15"),
+    selector.SelectOptionDict(value=DeviceTypes.INVERTER_120, label="RTU 2 - Inverter TL3-X (MAX, MID, MAC Type)"),
+    selector.SelectOptionDict(value=DeviceTypes.HYBRID_120, label="RTU 2 - Storage (MIX, SPA, SPH Type)"),
+    selector.SelectOptionDict(value=DeviceTypes.HYBRID_120_TL_XH, label="RTU 2 - Hybrid TL(3)-X(H) (MIN, MOD Type)"),
+    selector.SelectOptionDict(value=DeviceTypes.INVERTER_315, label="RTU - Inverter (Older generation) v3.15"),
     selector.SelectOptionDict(value=DeviceTypes.OFFGRID_SPF, label="SPF - Offgrid/Hybrid"),
 ]
 

--- a/custom_components/growatt_local/config_flow.py
+++ b/custom_components/growatt_local/config_flow.py
@@ -29,6 +29,7 @@ from .API.device_type.base import GrowattDeviceInfo
 from .const import (
     CONF_AC_PHASES,
     CONF_DC_STRING,
+    CONF_METER_CONNECTED,
     CONF_LAYER,
     CONF_SERIAL,
     CONF_TCP,
@@ -76,7 +77,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow class."""
 
     VERSION = 1
-    MINOR_VERSION = 4
+    MINOR_VERSION = 5
 
     def __init__(self):
         """Initialise growatt server flow."""
@@ -170,6 +171,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         device_type: str = DeviceTypes.INVERTER_120,
         mppt_trackers: int = 1,
         grid_phases: int = 1,
+        meter_connected: bool = False,
         modbus_version: float | str = "Not supported, Check logs for device info",
         detected_type: str = "unknown",
         scan_interval: int = 60,
@@ -203,6 +205,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         mode=selector.NumberSelectorMode.BOX,
                     ),
                 ),
+                vol.Required(CONF_METER_CONNECTED, default=meter_connected): bool,
                 vol.Required(CONF_SCAN_INTERVAL, default=scan_interval): int,
                 vol.Required(CONF_POWER_SCAN_ENABLED, default=power_scan_enabled): bool,
                 vol.Optional(CONF_POWER_SCAN_INTERVAL, default=power_scan_interval): int,
@@ -432,6 +435,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     device_type=user_input[CONF_TYPE],
                     mppt_trackers=user_input[CONF_DC_STRING],
                     grid_phases=user_input[CONF_AC_PHASES],
+                    meter_connected=user_input[CONF_METER_CONNECTED],
                     scan_interval=user_input[CONF_SCAN_INTERVAL],
                     power_scan_enabled=user_input[CONF_POWER_SCAN_ENABLED],
                     power_scan_interval=user_input[CONF_POWER_SCAN_INTERVAL],
@@ -447,6 +451,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     device_type=user_input[CONF_TYPE],
                     mppt_trackers=user_input[CONF_DC_STRING],
                     grid_phases=user_input[CONF_AC_PHASES],
+                    meter_connected=user_input[CONF_METER_CONNECTED],
                     scan_interval=user_input[CONF_SCAN_INTERVAL],
                     power_scan_enabled=user_input[CONF_POWER_SCAN_ENABLED],
                     power_scan_interval=user_input[CONF_POWER_SCAN_INTERVAL],
@@ -462,6 +467,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device_type=user_input[CONF_TYPE],
                 mppt_trackers=user_input[CONF_DC_STRING],
                 grid_phases=user_input[CONF_AC_PHASES],
+                meter_connected=user_input[CONF_METER_CONNECTED],
                 scan_interval=user_input[CONF_SCAN_INTERVAL],
                 power_scan_enabled=user_input[CONF_POWER_SCAN_ENABLED],
                 power_scan_interval=user_input[CONF_POWER_SCAN_INTERVAL],

--- a/custom_components/growatt_local/config_flow.py
+++ b/custom_components/growatt_local/config_flow.py
@@ -91,7 +91,7 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Create the options flow."""
-        return GrowattLocalOptionsFlow(config_entry)
+        return GrowattLocalOptionsFlow()
 
     @callback
     def _async_show_selection_form(self, errors=None):
@@ -490,10 +490,6 @@ class GrowattLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 class GrowattLocalOptionsFlow(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     @callback
     def _async_show_options_form(self, errors=None):
         return self.async_show_form(

--- a/custom_components/growatt_local/const.py
+++ b/custom_components/growatt_local/const.py
@@ -17,6 +17,7 @@ CONF_BYTESIZE = "bytesize"
 
 CONF_DC_STRING = "dc_string"
 CONF_AC_PHASES = "ac_phases"
+CONF_METER_CONNECTED = "meter_connected"
 
 CONF_POWER_SCAN_INTERVAL = "power_scan_interval"
 CONF_POWER_SCAN_ENABLED = "power_scan_enabled"

--- a/custom_components/growatt_local/sensor.py
+++ b/custom_components/growatt_local/sensor.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_AC_PHASES,
     CONF_DC_STRING,
     CONF_FIRMWARE,
+    CONF_METER_CONNECTED,
     CONF_SERIAL_NUMBER,
     CONF_POWER_SCAN_ENABLED,
     DOMAIN,
@@ -65,6 +66,8 @@ async def async_setup_entry(
     supported_key_names = coordinator.growatt_api.get_register_names()
 
     device_type = DeviceTypes(config_entry.data[CONF_TYPE])
+    meter_connected = config_entry.data.get(CONF_METER_CONNECTED, False)
+    modbus_version = (await coordinator.growatt_api.get_device_info()).modbus_version
 
     if device_type in (DeviceTypes.INVERTER, DeviceTypes.INVERTER_315, DeviceTypes.INVERTER_120,
                        DeviceTypes.HYBRID_120, DeviceTypes.HYBRID_120_TL_XH):
@@ -100,11 +103,12 @@ async def async_setup_entry(
                 continue
 
             sensor_descriptions.append(sensor)
-        for sensor in METER_SENSOR_TYPES:
-            if sensor.key not in supported_key_names:
-                continue
+        if meter_connected and modbus_version >= 1.38:
+            for sensor in METER_SENSOR_TYPES:
+                if sensor.key not in supported_key_names:
+                    continue
 
-            sensor_descriptions.append(sensor)
+                sensor_descriptions.append(sensor)
 
     if device_type in (DeviceTypes.INVERTER, DeviceTypes.INVERTER_315, DeviceTypes.INVERTER_120):
         power_sensor = (ATTR_INPUT_POWER, ATTR_OUTPUT_POWER)

--- a/custom_components/growatt_local/sensor.py
+++ b/custom_components/growatt_local/sensor.py
@@ -33,11 +33,12 @@ from .API.device_type.base import (
     ATTR_LOAD_PERCENTAGE,
     ATTR_PAC_TO_USER_TOTAL,
     ATTR_PAC_TO_GRID_TOTAL,
+    ATTR_METER_TOTAL_ACTIVE_POWER,
 )
 
 from .sensor_types.sensor_entity_description import GrowattSensorEntityDescription
 from .sensor_types.offgrid import OFFGRID_SENSOR_TYPES
-from .sensor_types.inverter import INVERTER_SENSOR_TYPES
+from .sensor_types.inverter import INVERTER_SENSOR_TYPES, METER_SENSOR_TYPES
 from .sensor_types.storage import STORAGE_SENSOR_TYPES
 from .const import (
     CONF_AC_PHASES,
@@ -99,15 +100,20 @@ async def async_setup_entry(
                 continue
 
             sensor_descriptions.append(sensor)
+        for sensor in METER_SENSOR_TYPES:
+            if sensor.key not in supported_key_names:
+                continue
+
+            sensor_descriptions.append(sensor)
 
     if device_type in (DeviceTypes.INVERTER, DeviceTypes.INVERTER_315, DeviceTypes.INVERTER_120):
         power_sensor = (ATTR_INPUT_POWER, ATTR_OUTPUT_POWER)
     elif device_type in (DeviceTypes.HYBRID_120, DeviceTypes.HYBRID_120_TL_XH):
         power_sensor = (ATTR_INPUT_POWER, ATTR_OUTPUT_POWER,
                         ATTR_SOC_PERCENTAGE, ATTR_DISCHARGE_POWER, ATTR_CHARGE_POWER,
-                        ATTR_PAC_TO_USER_TOTAL, ATTR_PAC_TO_GRID_TOTAL)
+                        ATTR_PAC_TO_USER_TOTAL, ATTR_PAC_TO_GRID_TOTAL, ATTR_METER_TOTAL_ACTIVE_POWER)
     elif device_type in (DeviceTypes.STORAGE_120, ):
-        power_sensor = (ATTR_SOC_PERCENTAGE, ATTR_DISCHARGE_POWER, ATTR_CHARGE_POWER)
+        power_sensor = (ATTR_SOC_PERCENTAGE, ATTR_DISCHARGE_POWER, ATTR_CHARGE_POWER, ATTR_METER_TOTAL_ACTIVE_POWER)
     elif device_type == DeviceTypes.OFFGRID_SPF:
         power_sensor = (ATTR_ACTIVE_POWER, ATTR_LOAD_PERCENTAGE, ATTR_DISCHARGE_POWER, ATTR_CHARGE_POWER)
     else:

--- a/custom_components/growatt_local/sensor.py
+++ b/custom_components/growatt_local/sensor.py
@@ -106,6 +106,9 @@ async def async_setup_entry(
                 continue
 
             sensor_descriptions.append(sensor)
+
+    if device_type in (DeviceTypes.INVERTER_120, DeviceTypes.HYBRID_120, DeviceTypes.HYBRID_120_TL_XH,
+                       DeviceTypes.STORAGE_120):
         if meter_connected and modbus_version >= 1.38:
             for sensor in METER_SENSOR_TYPES:
                 if sensor.key not in supported_key_names:

--- a/custom_components/growatt_local/sensor_types/inverter.py
+++ b/custom_components/growatt_local/sensor_types/inverter.py
@@ -81,6 +81,7 @@ from ..API.device_type.base import (
     ATTR_TEMPERATURE,
     ATTR_IPM_TEMPERATURE,
     ATTR_OUTPUT_PERCENTAGE,
+    ATTR_METER_TOTAL_ACTIVE_POWER,
 )
 
 INVERTER_POWER_SWITCH: GrowattSwitchEntityDescription = GrowattSwitchEntityDescription(
@@ -495,5 +496,15 @@ INVERTER_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
         key="status",
         name="Status",
         device_class=f"growatt_local__status"
+    ),
+)
+
+METER_SENSOR_TYPES: tuple[GrowattSensorEntityDescription, ...] = (
+    GrowattSensorEntityDescription(
+        key=ATTR_METER_TOTAL_ACTIVE_POWER,
+        name="Meter Total active power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )

--- a/custom_components/growatt_local/strings.json
+++ b/custom_components/growatt_local/strings.json
@@ -49,13 +49,14 @@
       },
       "device": {
         "title": "Define your Growatt device",
-        "description": "Based on the configration the following values are preset.\nAdditioanlly detected the following device type: {device_type}",
+        "description": "Based on the configration the following values are preset.\nAdditionally detected the following device type: {device_type}",
         "data": {
           "name": "Device name",
           "model": "Inverter model name",
           "type": "Device type",
           "dc_string": "Number of Solar strings",
           "ac_phases": "Number of AC phases",
+          "meter_connected": "Is a kWh meter connected?",
           "scan_interval": "General update interval",
           "power_scan_enabled": "Enable power update interval",
           "power_scan_interval": "Power update interval",
@@ -79,6 +80,7 @@
           "type": "Device type",
           "dc_string": "Number of Solar strings",
           "ac_phases": "Number of AC phases",
+          "meter_connected": "Is a kWh meter connected?",
           "scan_interval": "General update interval",
           "power_scan_enabled": "Enable power update interval",
           "power_scan_interval": "Power update interval",

--- a/custom_components/growatt_local/translations/en.json
+++ b/custom_components/growatt_local/translations/en.json
@@ -49,13 +49,14 @@
       },
       "device": {
         "title": "Define your Growatt device",
-        "description": "Based on the configration the following values are preset.\nAdditioanlly detected the following device type: {device_type}",
+        "description": "Based on the configration the following values are preset.\nAdditionally detected the following device type: {device_type}",
         "data": {
           "name": "Device name",
           "model": "Inverter model name",
           "type": "Device type",
           "dc_string": "Number of Solar strings",
           "ac_phases": "Number of AC phases",
+          "meter_connected": "Is a kWh meter connected?",
           "scan_interval": "General update interval",
           "power_scan_enabled": "Enable power update interval",
           "power_scan_interval": "Power update interval",
@@ -79,6 +80,7 @@
           "type": "Device type",
           "dc_string": "Number of Solar strings",
           "ac_phases": "Number of AC phases",
+          "meter_connected": "Is a kWh meter connected?",
           "scan_interval": "General update interval",
           "power_scan_enabled": "Enable power update interval",
           "power_scan_interval": "Power update interval",

--- a/custom_components/growatt_local/translations/nl.json
+++ b/custom_components/growatt_local/translations/nl.json
@@ -56,6 +56,7 @@
           "type": "Apparaat type",
           "dc_string": "Aantal PV strings",
           "ac_phases": "Aantal grid fasen",
+          "meter_connected": "Is een kWh meter aangesloten?",
           "scan_interval": "General update interval",
           "power_scan_enabled": "Enable seperate power update interval",
           "power_scan_interval": "Power update interval",
@@ -79,6 +80,7 @@
           "type": "Apparaat type",
           "dc_string": "Aantal PV strings",
           "ac_phases": "Aantal grid fasen",
+          "meter_connected": "Is een kWh meter aangesloten?",
           "scan_interval": "General update interval",
           "power_scan_enabled": "Enable seperate power update interval",
           "power_scan_interval": "Power update interval"


### PR DESCRIPTION
I have a MOD 6000TL3-XH with battery and energy meter setup. 

To accommodate registers that are only functional with a connected energy meter, I have added a checkbox option to the config flow allowing users to select that they have an energy meter connected.
I named the option: "Is a kWh meter connected?" and also added a dutch translation.
<img width="600" height="1231" alt="Screenshot 2026-01-01 at 21-14-06 Settings – Home Assistant" src="https://github.com/user-attachments/assets/d4740a4a-66bd-4619-b517-77adacea195a" />

I know the repo is currently limited to the modbus protocol II v1.20. However, since version v1.38 it is possible to read out the power measurements from the energy meter via the inverter registers. I added a measurement  "Meter Total active power" containing this register value and added a protection to make sure that only users that have a connected energy meter in their config and have modbus protocol II version v1.38 or higher get that measurement.
<img width="316" height="116" alt="Screenshot 2026-01-01 at 21-16-08 Settings – Home Assistant" src="https://github.com/user-attachments/assets/2ed514a3-5f63-4b0e-b4ad-3643f091f9d4" />

While working on the config flow option, I noticed that the options flow is broken. So, I added a small change to fix that too. And I also fixed some typos.

I hope that this change is not too large. I tried to keep it as concise as possible, so that it is still easy to review.

P.S. This change opens the door for adding the export limit registers in the future, as a connected energy meter is needed for the inverter to control the set export limits.